### PR TITLE
Update to latest docusign/esign-client && PHPUnit, Support DocuSign's new dynamic host URL requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   ],
   "require": {
     "php": "^7.2",
-    "docusign/esign-client": "^3.0"
+    "docusign/esign-client": "^4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "8.2.*"
@@ -23,6 +23,5 @@
     "psr-4": {
       "DocuSign\\Rest\\": "src/"
     }
-  },
-  "minimum-stability": "dev"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,11 +13,11 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
+    "php": "^7.2",
     "docusign/esign-client": "^3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "5.3.*"
+    "phpunit/phpunit": "8.2.*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Api/BaseApi.php
+++ b/src/Api/BaseApi.php
@@ -38,12 +38,17 @@ abstract class BaseApi
     public function __construct(ApiClient $apiClient)
     {
         $this->apiClient = $apiClient;
+        $this->initClient();
+    }
+
+    private function initClient()
+    {
         $docusignClass = str_replace(__NAMESPACE__, "DocuSign\\eSign\\Api", get_class($this)) . 'Api';
-        $this->client = new $docusignClass($apiClient->getClient());
+        $this->client = new $docusignClass($this->apiClient->getClient());
     }
 
     /**
-     * Magic method to construct an options model or call an apimethod
+     * Magic method to construct an options model or call an api method
      * @param $method
      * @param $args
      * @return mixed
@@ -56,7 +61,12 @@ abstract class BaseApi
         }
 
         if ($method !== 'login' && !$this->apiClient->isAuthenticated()) {
+            $host = $this->apiClient->getHost();
             $this->apiClient->authenticate();
+            // If the host has changed, update host on client config
+            if ($host !== $this->apiClient->getHost()) {
+                $this->initClient();
+            }
         }
 
         if ($this->usesAccountId) {
@@ -68,7 +78,7 @@ abstract class BaseApi
 
     /**
      * Get an options object or all of them for current Api class
-     * 
+     *
      * @param null $method
      * @return array|mixed
      * @throws ClassNotFoundException

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,7 +2,7 @@
 
 namespace DocuSign\Rest;
 
-use DocuSign\eSign\ApiClient;
+use DocuSign\eSign\Client\ApiClient;
 use DocuSign\eSign\Configuration;
 
 
@@ -123,7 +123,7 @@ class Client
         if (array_key_exists($name, $this->_api_container)) {
             return $this->_api_container[$name];
         }
-        
+
         if (!class_exists($apiClass = "DocuSign\\Rest\\Api\\" . ucfirst($name))) {
             throw new Exceptions\ClassNotFoundException("Cannot Find Api Class $apiClass");
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -67,6 +67,11 @@ class Client
             $this->{$key} = $val;
         }
 
+        $this->initApiClient();
+    }
+
+    private function initApiClient()
+    {
         $this->client = new ApiClient($this->setConfiguration());
     }
 
@@ -78,6 +83,11 @@ class Client
                 'Password'      => $this->password,
                 'IntegratorKey' => $this->integrator_key
             ]));
+    }
+
+    public function getHost()
+    {
+        return $this->host;
     }
 
     /**
@@ -132,7 +142,7 @@ class Client
     }
 
     /**
-     * Authenticates api client and stores account_id
+     * Authenticates api client, stores account_id, and updates host if changed by docusign
      *
      * @return $this
      */
@@ -140,9 +150,17 @@ class Client
     {
         if (!isset($this->account_id)) {
             $accounts = $this->authentication->login();
-            $allAccounts = $accounts->getLoginAccounts();
-            $account = $allAccounts[0];
+            $login_accounts = $accounts->getLoginAccounts();
+            $account = $login_accounts[0];
             $this->account_id = $account->getAccountId();
+            $base_url = $account->getBaseUrl();
+            $base_url = strtolower(substr($base_url, 0, strpos($base_url,'/restapi') + 8));
+            // If the host has changed, update host on client config
+            if ($this->host !== $base_url) {
+              $this->host = $base_url;
+              $this->_api_container = [];
+              $this->initApiClient();
+            }
         }
 
         $this->authenticated = true;

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class LoginTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class LoginTest extends TestCase
 {
 	public function testLogin()
 	{

--- a/tests/SignatureRequestTest.php
+++ b/tests/SignatureRequestTest.php
@@ -1,6 +1,8 @@
 <?php
 
-class SignatureRequestTest extends PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class SignatureRequestTest extends TestCase
 {
 	public function testSignatureRequest()
 	{


### PR DESCRIPTION
Just simply updates to the latest PHPUnit (8.2) and DocuSign PHP client (4.0)

According to DocuSign, the only breaking changes in 4.0 was moving ApiClient and ApiException to the DocuSign\eSign\Client namespace, which is a simple fix in src/Client.php. Since DocuSign host URLs can change for an account, according to [their docs](https://developers.docusign.com/esign-rest-api/guides/post-go-live#rest-api-integrations-with-legacy-authentication), the host URL is now dynamically updated to the base_url provided by DocuSign during authentication after using the initial host URL for auth.